### PR TITLE
Add flag that can be used to move the jwt token from the headers to response body

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -14,6 +14,8 @@ require "action_view/railtie"
 require "action_cable/engine"
 # require "rails/test_unit/railtie"
 
+require_relative '../lib/middleware/jwt_token_middleware.rb'
+
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
@@ -35,5 +37,10 @@ module RailsDeviseJwtTemplate
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+
+    Rails.application.config.middleware.insert_before(
+      ActionDispatch::Static,
+      JwtTokenMiddleware
+    )
   end
 end

--- a/config/initializers/features.rb
+++ b/config/initializers/features.rb
@@ -1,0 +1,5 @@
+SHOULD_PUT_JWT_TOKEN_IN_BODY = false
+
+def should_put_jwt_token_in_body?
+  SHOULD_PUT_JWT_TOKEN_IN_BODY
+end

--- a/lib/middleware/jwt_token_middleware.rb
+++ b/lib/middleware/jwt_token_middleware.rb
@@ -1,0 +1,21 @@
+class JwtTokenMiddleware
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    status, headers, response = @app.call(env)
+
+    if should_put_jwt_token_in_body? && headers['authorization'].present?
+      body = JSON.parse(response.first)
+
+      body['data']['token'] = headers['authorization'].split(' ').last
+
+      headers.delete('authorization')
+
+      response = Rack::Response.new([body.to_json], status, headers)
+    end
+
+    [status, headers, response]
+  end
+end


### PR DESCRIPTION
While following your tutorial I tried to figure out the best way to hand out the jwt token to clients in the body of the json response instead of the header.

What I did is create some middleware to grab the jwt token from the headers and move it to the response body.

Being a rails n00b, I'm not convinced this is the best approach, so any feedback would be greatly appreciated to change this functionality =)